### PR TITLE
add colab notebook and gradio demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Read about it at https://www.riffusion.com/about and try it at https://www.riffu
 * Web app: https://github.com/hmartiro/riffusion-app
 * Inference server: https://github.com/hmartiro/riffusion-inference
 * Model checkpoint: https://huggingface.co/riffusion/riffusion-model-v1
+* Google Colab notebook: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1FhH3HlN8Ps_Pr9OR6Qcfbfz7utDvICl0?usp=sharing)
+
 
 This repository contains the interactive web app that powers the website.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Read about it at https://www.riffusion.com/about and try it at https://www.riffu
 * Inference server: https://github.com/hmartiro/riffusion-inference
 * Model checkpoint: https://huggingface.co/riffusion/riffusion-model-v1
 * Google Colab notebook: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1FhH3HlN8Ps_Pr9OR6Qcfbfz7utDvICl0?usp=sharing)
+* Gradio Web Demo: [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/fffiloni/spectrogram-to-music)
 
 
 This repository contains the interactive web app that powers the website.


### PR DESCRIPTION
added a colab notebook by https://twitter.com/0xjasper/status/1603441434966859778, to run with a gradio web app inside colab with gpu

as well as a gradio demo hosted on huggingface to try it out: https://huggingface.co/spaces/fffiloni/spectrogram-to-music